### PR TITLE
feat: Add Mandoline CI integration for code quality evaluation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
     strategy:
       matrix:
         node-version: [18.x, 20.x, 22.x]
@@ -34,3 +34,32 @@ jobs:
 
       - name: Run all checks
         run: npm run check
+
+  mandoline-eval:
+    name: Mandoline Evaluation
+    runs-on: ubuntu-latest
+    needs: test
+    if: success()
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Run Mandoline evaluation
+        env:
+          MANDOLINE_API_KEY: ${{ secrets.MANDOLINE_API_KEY }}
+        run: npx mandoline-ci run --verbose

--- a/mandoline-ci.config.mjs
+++ b/mandoline-ci.config.mjs
@@ -1,0 +1,43 @@
+// This configuration evaluates the project's own code changes
+
+export default [
+  {
+    name: 'src',
+    files: ['src/**/*.ts', '!src/**/*.test.ts', '!src/**/*.spec.ts'],
+    ignores: ['src/__tests__/**/*'],
+    rules: {
+      'architecture-consistency': {
+        metricId: '939608a0-e123-4272-86cb-f09622a923c2', // Patterns that enable rapid iteration vs rigidity
+        threshold: -0.1,
+      },
+      'intent-implementation': {
+        metricId: '4e91e7fb-d49a-4ae9-967f-558cc5fec712', // Semantic alignment with focus on core problem solving
+        threshold: -0.1,
+      },
+      'code-quality': {
+        metricId: '682158de-207a-4f61-81b6-207f4f40ac05', // Readable, maintainable, pragmatic code quality
+        threshold: -0.1,
+      },
+    },
+  },
+  {
+    name: 'tests',
+    files: ['src/**/*.test.ts', 'src/**/*.spec.ts'],
+    rules: {
+      'test-quality': {
+        metricId: '6070d5a1-d318-404a-9b93-e7a4f276ac08', // Critical paths over comprehensive coverage
+        threshold: -0.333,
+      },
+    },
+  },
+  {
+    name: 'docs',
+    files: ['*.md', 'docs/**/*'],
+    rules: {
+      'documentation-quality': {
+        metricId: '1d000831-83df-4d0f-b244-f432dd8d5778', // Clear, insight-dense docs that teach vs describe
+        threshold: -0.1,
+      },
+    },
+  },
+];


### PR DESCRIPTION
## Summary
- Add Mandoline CI integration to evaluate code changes during CI pipeline
- Configure lean development-focused quality metrics with pragmatic thresholds
- Separate evaluation rules for src/, tests/, and docs/ with appropriate criteria

## Changes
- Added `mandoline-eval` job to CI workflow that runs after successful tests
- Created `mandoline-ci.config.mjs` with 5 quality metrics:
  - **Architecture Consistency**: Rewards patterns enabling rapid iteration vs rigidity
  - **Intent Implementation**: Focuses on solving core problems vs over-implementing  
  - **Code Quality**: Pragmatic "good enough" quality that ships and iterates
  - **Test Quality**: Critical paths over comprehensive coverage (more lenient -0.333 threshold)
  - **Documentation Quality**: Insight-dense docs that teach vs describe

## Test Plan
- [x] Installed mandoline-ci globally and tested CLI locally
- [x] Verified configuration loads and runs successfully
- [x] Integration runs only after successful test completion
- [x] API key configured via GitHub secrets

🤖 Generated with [Claude Code](https://claude.ai/code)